### PR TITLE
Add GIT_COMMIT to process environment

### DIFF
--- a/pypaas/checkout.py
+++ b/pypaas/checkout.py
@@ -2,13 +2,11 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 import copy
 import shutil
 import os.path
 import datetime
 import subprocess
-from configparser import ConfigParser
 
 from . import options
 

--- a/pypaas/runners/nginxbackend.py
+++ b/pypaas/runners/nginxbackend.py
@@ -3,12 +3,7 @@
 
 import copy
 import os
-import os.path
-import shutil
-import subprocess
-import sys
 
-from .. import util
 from ..portallocator import Port
 from .base import NginxBase
 from .simpleprocess import SimpleProcess

--- a/pypaas/runners/simpleprocess.py
+++ b/pypaas/runners/simpleprocess.py
@@ -103,7 +103,7 @@ class SimpleProcess(BaseRunner):
                 for i in range(self.config.get('process_count', 1))]
 
     def get_process_env(self, **kwargs):
-        return self.branch.config['env']
+        return self.branch.current_checkout.cmd_env
 
     def configure(self):
         util.mkdir_p(os.path.expanduser('~/services/'))


### PR DESCRIPTION
Currently only the commands used to build checkouts or run migrations have access to the git commit id. This also adds the `GIT_COMMIT` to the environment of the server processes.

While working on that feature my editor flagged a few unused imports so I just got rid of them as well.