### PR TITLE
Fix deprecation warnings about yaml.load(str)

### DIFF
--- a/pypaas/options.py
+++ b/pypaas/options.py
@@ -2,10 +2,9 @@
 import errno
 import os
 import os.path
+from configparser import ConfigParser
 
 import yaml
-
-from configparser import ConfigParser
 
 main = {}
 repos = {}
@@ -20,21 +19,21 @@ def load_config():
     for configpath in ['~/config', '/etc/pypaas']:
         configpath = os.path.expanduser(configpath)
         if os.path.isfile(os.path.join(configpath, 'pypaas.yml')):
-            main = yaml.load(open(os.path.join(configpath, 'pypaas.yml')))
+            main = yaml.load(open(os.path.join(configpath, 'pypaas.yml')), Loader=yaml.FullLoader)
             for repo in os.listdir(os.path.join(configpath, 'repos')):
                 if not repo.endswith('.yml'):
                     continue
                 repo = repo[:-(len('.yml'))]
                 repos[repo] = yaml.load(open(
                     os.path.join(configpath, 'repos', repo + '.yml')
-                ))
+                ), Loader=yaml.FullLoader)
             for domain in os.listdir(os.path.join(configpath, 'domains')):
                 if not domain.endswith('.yml'):
                     continue
                 domain = domain[:-(len('.yml'))]
                 domains[domain] = yaml.load(open(
                     os.path.join(configpath, 'domains', domain + '.yml')
-                ))
+                ), Loader=yaml.FullLoader)
             break
 
 load_config()

--- a/pypaas/portallocator.py
+++ b/pypaas/portallocator.py
@@ -56,7 +56,7 @@ class Port(object):
     @staticmethod
     def get_state():
         try:
-            state = yaml.load(open(os.path.expanduser('~/ports.yml')))
+            state = yaml.load(open(os.path.expanduser('~/ports.yml')), Loader=yaml.FullLoader)
             return state if state is not None else {}
         except FileNotFoundError:
             return {}

--- a/pypaas/runners/base.py
+++ b/pypaas/runners/base.py
@@ -37,7 +37,7 @@ class BaseRunner(object):
     def in_maintenance(self):
         try:
             with open(os.path.expanduser('~/maintenance-state.yml')) as f:
-                state = yaml.load(f)
+                state = yaml.load(f, Loader=yaml.FullLoader)
                 return self.name in state
         except FileNotFoundError:
             return False
@@ -45,7 +45,7 @@ class BaseRunner(object):
     def enable_maintenance(self):
         try:
             with open(os.path.expanduser('~/maintenance-state.yml')) as f:
-                state = yaml.load(f)
+                state = yaml.load(f, Loader=yaml.FullLoader)
         except FileNotFoundError:
             state = dict()
         state[self.name] = {
@@ -59,7 +59,7 @@ class BaseRunner(object):
     def disable_maintenance(self):
         try:
             with open(os.path.expanduser('~/maintenance-state.yml')) as f:
-                state = yaml.load(f)
+                state = yaml.load(f, Loader=yaml.FullLoader)
         except FileNotFoundError:
             state = dict()
         if self.name in state:


### PR DESCRIPTION
PyYAML deprecated yaml.load(str) because of an exploit leading to a arbitrary code execution (See [CVE](https://nvd.nist.gov/vuln/detail/CVE-2017-18342). The user must now intentionally specify the Loader to be used (and which still allows to use the unsafe loader). The most probable intention for this project is probably to use the `FullLoader`. This allows the use of the full YAML syntax but avoids the arbitrary code execution.

More information: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation