### PR TITLE
Update default tls config

### DIFF
--- a/pypaas/domain.py
+++ b/pypaas/domain.py
@@ -161,16 +161,16 @@ class Domain(object):
                 'ssl_config',
                 options.main.get(
                     'ssl_config',
-                    # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.10.3&openssl=1.0.2l&hsts=yes&profile=intermediate
+                    # https://ssl-config.mozilla.org/#server=nginx&version=1.14.2&config=intermediate&openssl=1.1.1d&guideline=5.6
                     '''
                         ssl_dhparam /etc/ssl/private/httpd/dhparam.pem;
                         ssl_session_timeout 1d;
-                        ssl_session_cache shared:SSL:50m;
+                        ssl_session_cache shared:MozSSL:10m;
                         ssl_session_tickets off;
-                        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-                        ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-                        ssl_prefer_server_ciphers on;
-                        add_header Strict-Transport-Security max-age=15768000;
+                        ssl_protocols TLSv1.2 TLSv1.3;
+                        ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
+                        ssl_prefer_server_ciphers off;
+                        add_header Strict-Transport-Security "max-age=63072000" always;
                         ssl_stapling on;
                         ssl_stapling_verify on;
                         resolver 8.8.8.8 8.8.4.4;


### PR DESCRIPTION
TLS 1.0 and 1.1 has been deprecated and removed from the most common used web browsers. Other recommendations of the Mozilla SSL Configuration Generator have also been applied. The configuration is compatible with the packages shipped in the current Debian Stable distribution.

For more information see:
- https://chromestatus.com/feature/5759116003770368
- https://blog.mozilla.org/security/2018/10/15/removing-old-versions-of-tls/
- https://ssl-config.mozilla.org/#server=nginx&version=1.14.2&config=intermediate&openssl=1.1.1d&guideline=5.6